### PR TITLE
Markdown template support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.idea
+.eggs
+*.egg-info
+__pycache__

--- a/src/ansible_doc_extractor/cli.py
+++ b/src/ansible_doc_extractor/cli.py
@@ -75,6 +75,7 @@ def render_module_docs(output_folder, module, template, extension):
 
 def get_template(custom_template):
     env = Environment(loader=PackageLoader(__name__), trim_blocks=True)
+    env.filters["ensure_list"] = ensure_list
     if custom_template:
         extension = custom_template.name.split('.')[-2]
         if extension not in _supported_templates:

--- a/src/ansible_doc_extractor/cli.py
+++ b/src/ansible_doc_extractor/cli.py
@@ -45,6 +45,7 @@ def md_ify(text):
     t = _URL.sub(r"\1", t)
     t = _CONST.sub(r"`\1`", t)
     t = _RULER.sub(r"------------", t)
+
     return t
 
 
@@ -98,6 +99,7 @@ def render_module_docs(output_folder, module, template, extension):
 def get_template(custom_template, markdown):
     env = Environment(loader=PackageLoader(__name__), trim_blocks=True)
     if custom_template:
+        env.filters["rst_ify"] = rst_ify
         template = env.from_string(custom_template.read())
         custom_template.close()
         extension = "rst"
@@ -115,7 +117,7 @@ def get_template(custom_template, markdown):
 def render_docs(output, modules, custom_template, markdown):
     template, extension = get_template(custom_template, markdown)
     for module in modules:
-        render_module_docs(output, module, template, markdown)
+        render_module_docs(output, module, template, extension)
 
 
 class ArgParser(argparse.ArgumentParser):
@@ -145,8 +147,9 @@ def create_argument_parser():
         help="Custom Jinja2 template used to generate documentation."
     )
     parser.add_argument(
-        "--markdown",
-        help="Generate markdown output files instead of rst."
+        "--markdown", action='store_true',
+        help="""Generate markdown output files instead of rst (default).
+                Ignored if --template is specified."""
     )
     return parser
 

--- a/src/ansible_doc_extractor/cli.py
+++ b/src/ansible_doc_extractor/cli.py
@@ -122,8 +122,7 @@ def create_argument_parser():
     )
     parser.add_argument(
         "--template", type=argparse.FileType('r'),
-        help="Custom Jinja2 template used to generate documentation. "
-             "Can be rst or md."
+        help="Custom Jinja2 template used to generate documentation."
     )
     return parser
 

--- a/src/ansible_doc_extractor/templates/module.md.j2
+++ b/src/ansible_doc_extractor/templates/module.md.j2
@@ -1,0 +1,152 @@
+{% if short_description %}
+{%   set title = module + ' -- ' + short_description | md_ify %}
+{% else %}
+{%   set title = module %}
+{% endif %}
+# {{ title }}
+
+{% if description -%}
+## Synopsis
+
+{%   for desc in description %}
+{{ desc | md_ify }}
+
+{%   endfor %}
+{% endif %}
+
+
+{% if requirements -%}
+## Requirements
+
+The below requirements are needed on the host that executes this module.
+
+{%   for req in requirements %}
+- {{ req | md_ify }}
+{%   endfor %}
+{% endif %}
+
+
+{% macro option_desc(opts, level) %}
+{%   for name, spec in opts.items() %}
+{%     set req = spec.required | default("optional") %}
+{%     set typ = spec.type | default("any") %}
+{%     set def_val = spec.default | default("None") %}
+  {{ "  " * level }}{{ name }} ({{ req }}, {{ typ }}, {{ def_val }})
+{%     for para in spec.description %}
+    {{ "  " * level }}{{ para | md_ify }}
+
+{%     endfor %}
+
+{%     if spec.suboptions %}
+{{ option_desc(spec.suboptions, level + 1) }}
+{%     endif %}
+{%   endfor %}
+{% endmacro %}
+
+{% if options -%}
+## Parameters
+
+{{ option_desc(options, 0) }}
+{% endif %}
+
+
+{% if notes -%}
+## Notes
+
+{%   for note in notes %}
+   - {{ note | md_ify }}
+{%   endfor %}
+{% endif %}
+
+
+{% if seealso -%}
+## See Also
+
+{% for item in seealso %}
+{%   if item.module is defined and item.description is defined %}
+   :ref:`{{ item.module }}_module`
+       {{ item.description | md_ify }}
+{%   elif item.module is defined %}
+   :ref:`{{ item.module }}_module`
+      The official documentation on the **{{ item.module }}** module.
+{%   elif item.name is defined and item.link is defined and item.description is defined %}
+   `{{ item.name }} <{{ item.link }}>`_
+       {{ item.description | md_ify }}
+{%   elif item.ref is defined and item.description is defined %}
+   :ref:`{{ item.ref }}`
+       {{ item.description | md_ify }}
+{%   endif %}
+{% endfor %}
+{% endif %}
+
+
+{% if examples -%}
+## Examples
+
+```yaml
+{{ examples | indent(4, True) }}
+```
+{% endif %}
+
+{% macro result_desc(results, level) %}
+{%   for name, spec in results.items() %}
+{%     set ret = spec.returned %}
+{%     set typ = spec.type | default("any") %}
+{%     set sample = spec.sample %}
+  {{ "  " * level }}{{ name }} ({{ ret }}, {{ typ }}, {{ sample }})
+    {{ "  " * level }}{{ spec.description | md_ify }}
+
+{%     if spec.contains %}
+{{ result_desc(spec.contains, level + 1) }}
+{%     endif %}
+{%   endfor %}
+{% endmacro %}
+
+{% if returndocs -%}
+## Return Values
+
+{{ result_desc(returndocs, 0) }}
+{% endif %}
+
+
+## Status
+
+{% if deprecated %}
+
+- This {{ plugin_type }} will be removed in version
+  {{ deprecated['removed_in'] | default('') | string | md_ify }}.
+  *[deprecated]*
+
+{% else %}
+
+{% set module_states = {
+     "preview": "not guaranteed to have a backwards compatible interface",
+     "stableinterface": "guaranteed to have backward compatible interface changes going forward",
+   }
+%}
+
+{%   if metadata %}
+{%     if metadata.status %}
+
+{%       for cur_state in metadata.status %}
+- This {{ plugin_type }} is {{ module_states[cur_state] }}. *[{{ cur_state }}]*
+{%       endfor %}
+
+{%     endif %}
+
+{%     if metadata.supported_by %}
+- This {{ plugin_type }} is maintained by {{ metadata.supported_by }}.
+{%     endif %}
+
+{%   endif %}
+
+{% endif %}
+
+{% if author is defined -%}
+## Authors
+
+{%   for author_name in author %}
+- {{ author_name }}
+{%   endfor %}
+
+{% endif %}

--- a/src/ansible_doc_extractor/templates/module.md.j2
+++ b/src/ansible_doc_extractor/templates/module.md.j2
@@ -89,7 +89,9 @@ The below requirements are needed on the host that executes this module.
 {%     set typ = spec.type | default("any") %}
 {%     set sample = spec.sample %}
   {{ "  " * level }}{{ name }} ({{ ret }}, {{ typ }}, {{ sample }})
-    {{ "  " * level }}{{ spec.description | md_ify }}
+{% for desc_line in spec.description  %}
+    {{ "  " * level }}{{ desc_line | md_ify }}
+{% endfor %}
 
 {%     if spec.contains %}
 {{ result_desc(spec.contains, level + 1) }}

--- a/src/ansible_doc_extractor/templates/module.md.j2
+++ b/src/ansible_doc_extractor/templates/module.md.j2
@@ -29,8 +29,9 @@ The below requirements are needed on the host that executes this module.
 {%     set req = spec.required | default("optional") %}
 {%     set typ = spec.type | default("any") %}
 {%     set def_val = spec.default | default("None") %}
+{%     set description = spec.description | ensure_list %}
   {{ "  " * level }}{{ name }} ({{ req }}, {{ typ }}, {{ def_val }})
-{%     for para in spec.description %}
+{%     for para in description %}
     {{ "  " * level }}{{ para | md_ify }}
 
 {%     endfor %}

--- a/src/ansible_doc_extractor/templates/module.md.j2
+++ b/src/ansible_doc_extractor/templates/module.md.j2
@@ -14,7 +14,6 @@
 {%   endfor %}
 {% endif %}
 
-
 {% if requirements -%}
 ## Requirements
 
@@ -24,7 +23,6 @@ The below requirements are needed on the host that executes this module.
 - {{ req | md_ify }}
 {%   endfor %}
 {% endif %}
-
 
 {% macro option_desc(opts, level) %}
 {%   for name, spec in opts.items() %}
@@ -36,7 +34,6 @@ The below requirements are needed on the host that executes this module.
     {{ "  " * level }}{{ para | md_ify }}
 
 {%     endfor %}
-
 {%     if spec.suboptions %}
 {{ option_desc(spec.suboptions, level + 1) }}
 {%     endif %}
@@ -47,18 +44,16 @@ The below requirements are needed on the host that executes this module.
 ## Parameters
 
 {{ option_desc(options, 0) }}
+
 {% endif %}
-
-
 {% if notes -%}
 ## Notes
 
 {%   for note in notes %}
    - {{ note | md_ify }}
 {%   endfor %}
+
 {% endif %}
-
-
 {% if seealso -%}
 ## See Also
 
@@ -77,17 +72,16 @@ The below requirements are needed on the host that executes this module.
        {{ item.description | md_ify }}
 {%   endif %}
 {% endfor %}
+
 {% endif %}
-
-
 {% if examples -%}
 ## Examples
 
 ```yaml
 {{ examples | indent(4, True) }}
 ```
-{% endif %}
 
+{% endif %}
 {% macro result_desc(results, level) %}
 {%   for name, spec in results.items() %}
 {%     set ret = spec.returned %}
@@ -106,11 +100,9 @@ The below requirements are needed on the host that executes this module.
 ## Return Values
 
 {{ result_desc(returndocs, 0) }}
+
 {% endif %}
-
-
 ## Status
-
 {% if deprecated %}
 
 - This {{ plugin_type }} will be removed in version
@@ -124,22 +116,17 @@ The below requirements are needed on the host that executes this module.
      "stableinterface": "guaranteed to have backward compatible interface changes going forward",
    }
 %}
-
 {%   if metadata %}
 {%     if metadata.status %}
-
 {%       for cur_state in metadata.status %}
 - This {{ plugin_type }} is {{ module_states[cur_state] }}. *[{{ cur_state }}]*
 {%       endfor %}
-
 {%     endif %}
 
 {%     if metadata.supported_by %}
 - This {{ plugin_type }} is maintained by {{ metadata.supported_by }}.
 {%     endif %}
-
 {%   endif %}
-
 {% endif %}
 
 {% if author is defined -%}
@@ -148,5 +135,4 @@ The below requirements are needed on the host that executes this module.
 {%   for author_name in author %}
 - {{ author_name }}
 {%   endfor %}
-
 {% endif %}


### PR DESCRIPTION
PR for preview and discussion of possible implementation of markdown support. This is not ready for merge yet.

Added .gitignore for PyCharm files, plus other files generated when using `pip install -e .` to test the code locally.
md_ify still needs transforming for all elements.
module.md.j2 included for reference, not necessarily for inclusion in final release. It would need a flag to switch between this and the default .rst template, as it would be tricky to pass the full path to this file after this package is installed via pip. 