### PR TITLE
Fix returndocs support for ansible 2.10

### DIFF
--- a/src/ansible_doc_extractor/cli.py
+++ b/src/ansible_doc_extractor/cli.py
@@ -60,9 +60,13 @@ def render_module_docs(output_folder, module, template):
         module, fragment_loader,
     )
 
+    returndocs = returndocs or {}
+    if isinstance(returndocs, str):
+        returndocs = yaml.safe_load(returndocs)
+
     doc.update(
         examples=examples,
-        returndocs=yaml.safe_load(returndocs) if returndocs else {},
+        returndocs=returndocs,
         metadata=metadata,
     )
 


### PR DESCRIPTION
The internal behavior of `ansible.parsing.plugin_docs.read_docstring()`
changed between ansible 2.9.3 and ansible 2.10.0. Now, ansible is
parsing the returndocs where it only returned a string before.

I found this problem with ansible-collections/community.mongodb#195
when the github workflow started using ansible 2.10.0 instead of 2.9.3.

You can see the issue in this workflow:
https://github.com/ansible-collections/community.mongodb/actions?query=workflow%3Adocumentation
With this traceback:
```
Rendering plugins/modules/mongodb_balancer.py
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.6.12/x64/bin/ansible-doc-extractor", line 8, in <module>
    sys.exit(main())
  File "/opt/hostedtoolcache/Python/3.6.12/x64/lib/python3.6/site-packages/ansible_doc_extractor/cli.py", line 134, in main
    render_docs(args.output, args.module, args.template)
  File "/opt/hostedtoolcache/Python/3.6.12/x64/lib/python3.6/site-packages/ansible_doc_extractor/cli.py", line 100, in render_docs
    render_module_docs(output, module, template)
  File "/opt/hostedtoolcache/Python/3.6.12/x64/lib/python3.6/site-packages/ansible_doc_extractor/cli.py", line 65, in render_module_docs
    returndocs=yaml.safe_load(returndocs) if returndocs else {},
  File "/opt/hostedtoolcache/Python/3.6.12/x64/lib/python3.6/site-packages/yaml/__init__.py", line 162, in safe_load
    return load(stream, SafeLoader)
  File "/opt/hostedtoolcache/Python/3.6.12/x64/lib/python3.6/site-packages/yaml/__init__.py", line 112, in load
    loader = Loader(stream)
  File "/opt/hostedtoolcache/Python/3.6.12/x64/lib/python3.6/site-packages/yaml/loader.py", line 34, in __init__
    Reader.__init__(self, stream)
  File "/opt/hostedtoolcache/Python/3.6.12/x64/lib/python3.6/site-packages/yaml/reader.py", line 85, in __init__
    self.determine_encoding()
  File "/opt/hostedtoolcache/Python/3.6.12/x64/lib/python3.6/site-packages/yaml/reader.py", line 124, in determine_encoding
    self.update_raw()
  File "/opt/hostedtoolcache/Python/3.6.12/x64/lib/python3.6/site-packages/yaml/reader.py", line 178, in update_raw
    data = self.stream.read(size)
AttributeError: 'AnsibleMapping' object has no attribute 'read'
```

returndocs comes from `ansible.utils.plugin_docs.get_docstring() => ansible.parsing.plugin_docs.read_docstring()`.

The relevant change in ansible's code:

https://github.com/ansible/ansible/blob/v2.9.3/lib/ansible/parsing/plugin_docs.py#L57-L62
https://github.com/ansible/ansible/blob/v2.10.0/lib/ansible/parsing/plugin_docs.py#L59-L65