### PR TITLE
Remove Ansible dependency

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,10 @@ Quickstart
 Documentation extractor is published on PyPI_ and we can install it using
 ``pip``::
 
-   $ pip install ansible-doc-extractor
+   $ pip install ansible-doc-extractor  # If we already have ansible installed
+   $ pip install ansible-doc-extractor[ansible]  # To also install ansible
+   $ pip install ansible-doc-extractor[base]  # To also install ansible-base
+   $ pip install ansible-doc-extractor[core]  # To also install ansible-core
 
 If the previous command did not fail, we are ready to start extracting the
 documentation::

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,9 +25,16 @@ include_package_data = True
 setup_requires =
   setuptools_scm
 install_requires =
-  ansible
   jinja2
   PyYAML
+
+[options.extras_require]
+ansible =
+  ansible
+base =
+  ansible-base
+core =
+  ansible-core
 
 [options.packages.find]
 where = src

--- a/src/ansible_doc_extractor/cli.py
+++ b/src/ansible_doc_extractor/cli.py
@@ -5,9 +5,13 @@ import os.path
 import re
 import sys
 
-from ansible.plugins.filter.core import to_yaml
-from ansible.plugins.loader import fragment_loader
-from ansible.utils import plugin_docs
+try:
+    from ansible.plugins.filter.core import to_yaml
+    from ansible.plugins.loader import fragment_loader
+    from ansible.utils import plugin_docs
+    HAS_ANSIBLE = True
+except ImportError:
+    HAS_ANSIBLE = False
 
 from jinja2 import Environment, PackageLoader
 from jinja2.runtime import Undefined
@@ -136,5 +140,12 @@ def create_argument_parser():
 
 
 def main():
+    if not HAS_ANSIBLE:
+        print(
+            "Please install 'ansible' or 'ansible-base' or 'ansible-core'.",
+            file=sys.stderr
+        )
+        sys.exit(1)
+
     args = create_argument_parser().parse_args()
     render_docs(args.output, args.module, args.template)


### PR DESCRIPTION
Since the functionality we use from the upstream can come in three different packages, we rely on users to provide the one they wish to use.