### PR TITLE
Remove pipenv

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,9 +1,0 @@
-[[source]]
-name = "pypi"
-url = "https://pypi.org/simple"
-verify_ssl = true
-
-[dev-packages]
-
-[packages]
-ansible-doc-extractor = {editable = true,path = "."}

--- a/README.rst
+++ b/README.rst
@@ -75,11 +75,12 @@ You can always refer to the `default Jinja2 template`_.
 Development setup
 -----------------
 
-Getting development environment up and running is relatively simple if we
-have ``pipenv`` installed::
+Getting development environment up and running is relatively simple::
 
-   $ pipenv update
+   $ python3 -m venv venv
+   $ . venv/bin/activate
+   (venv) $ pip install -e .
 
 To test the extractor, we can run::
 
-   $ pipenv run ansible-doc-extractor
+   $ ansible-doc-extractor


### PR DESCRIPTION
Pipenv seemed like a good idea at the time, but it turned out to be just a source of extra work, so we are dropping it in favor of good-old pip.