### PR TITLE
KeyError when module has no options defined

### DIFF
--- a/src/ansible_doc_extractor/cli.py
+++ b/src/ansible_doc_extractor/cli.py
@@ -77,7 +77,7 @@ def render_module_docs(output_folder, module, template):
 
     doc["author"] = ensure_list(doc["author"])
     doc["description"] = ensure_list(doc["description"])
-    convert_descriptions(doc["options"])
+    convert_descriptions(doc.get("options", {}))
     convert_descriptions(doc["returndocs"])
 
     if "module" in doc:


### PR DESCRIPTION
I have a module with no options that I was trying to extract documentation from, but it would trigger a KeyError.