### PR TITLE
Added python_requires

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ setup_requires =
 install_requires =
   jinja2
   PyYAML
+python_requires = '>=3.6'
 
 [options.extras_require]
 ansible =


### PR DESCRIPTION
Addresses issue #19.

Added python_requires to setup.cfg with '>=3.6' in order to have it in the package metadata for use by pip.
