### PR TITLE
Use antsibull-docs-parser to render semantic markup

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ setup_requires =
 install_requires =
   jinja2
   PyYAML
-  antsibull-docs-parser ~= 0.3.0
+  antsibull-docs-parser >= 1.0.0, < 2.0.0
 python_requires = >=3.6
 
 [options.extras_require]

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,6 +33,7 @@ setup_requires =
 install_requires =
   jinja2
   PyYAML
+  antsibull-docs-parser ~= 0.3.0
 python_requires = >=3.6
 
 [options.extras_require]


### PR DESCRIPTION
Uses the Python library [antsibull-docs-parser](https://pypi.org/project/antsibull-docs-parser/) (https://github.com/ansible-community/antsibull-docs-parser) to render Ansible markup, including the new semantic markup.

The plain RST created by antsibull-docs-parser is slightly different from the one created by the original code:
```diff
diff output/wait_for_txt.rst.orig output/wait_for_txt.rst
15c15
< Wait for TXT entries with specific values to show up on **all** authoritative nameservers for the DNS name.
---
> Wait for TXT entries with specific values to show up on \ :strong:`all`\  authoritative nameservers for the DNS name.
23c23
< - dnspython >= 1.15.0 (maybe older versions also work)
---
> - dnspython \>= 1.15.0 (maybe older versions also work)
35c35
<       A DNS name, like ``www.example.com``.
---
>       A DNS name, like \ :literal:`www.example.com`\ .
43c43
<       Comparison modes for the values in *values*.
---
>       Comparison modes for the values in \ :emphasis:`values`\ .
45c45
<       If ``subset``, *values* should be a (not necessarily proper) subset of the TXT values set for the DNS name.
---
>       If \ :literal:`subset`\ , \ :emphasis:`values`\  should be a (not necessarily proper) subset of the TXT values set for the DNS name.
47c47
<       If ``superset``, *values* should be a (not necessarily proper) superset of the TXT values set for the DNS name. This includes the case that no TXT entries are set.
---
>       If \ :literal:`superset`\ , \ :emphasis:`values`\  should be a (not necessarily proper) superset of the TXT values set for the DNS name. This includes the case that no TXT entries are set.
49c49
<       If ``superset_not_empty``, *values* should be a (not necessarily proper) superset of the TXT values set for the DNS name, assuming at least one TXT record is present.
---
>       If \ :literal:`superset\_not\_empty`\ , \ :emphasis:`values`\  should be a (not necessarily proper) superset of the TXT values set for the DNS name, assuming at least one TXT record is present.
51c51
<       If ``equals``, *values* should be the same set of strings as the TXT values for the DNS name (up to order).
---
>       If \ :literal:`equals`\ , \ :emphasis:`values`\  should be the same set of strings as the TXT values for the DNS name (up to order).
53c53
<       If ``equals_ordered``, *values* should be the same ordered list of strings as the TXT values for the DNS name.
---
>       If \ :literal:`equals\_ordered`\ , \ :emphasis:`values`\  should be the same ordered list of strings as the TXT values for the DNS name.
76c76
<     When set to ``true`` (default), will use the default resolver to find the authoritative nameservers of a subzone.
---
>     When set to \ :literal:`true`\  (default), will use the default resolver to find the authoritative nameservers of a subzone.
78c78
<     When set to ``false``, will use the authoritative nameservers of the parent zone to find the authoritative nameservers of a subzone. This only makes sense when the nameservers were recently changed and haven't propagated.
---
>     When set to \ :literal:`false`\ , will use the authoritative nameservers of the parent zone to find the authoritative nameservers of a subzone. This only makes sense when the nameservers were recently changed and haven't propagated.
116c116
<   The entries are in a 1:1 correspondence to the entries of the *records* parameter, in exactly the same order.
---
>   The entries are in a 1:1 correspondence to the entries of the \ :emphasis:`records`\  parameter, in exactly the same order.
```
This are the docs generated from the community.dns.wait_for_txt plugin.

(I marked this as a draft since I want to wait a bit until antsibull-docs-parser reaches 1.0.0 before making this ready.)