### PR TITLE
Configure collection loader before rendering docs

### DIFF
--- a/src/ansible_doc_extractor/cli.py
+++ b/src/ansible_doc_extractor/cli.py
@@ -8,6 +8,10 @@ try:
     from ansible.plugins.loader import fragment_loader
     from ansible.utils import plugin_docs
     HAS_ANSIBLE = True
+    try:
+        from ansible.plugins.loader import init_plugin_loader
+    except ImportError:
+        pass
 except ImportError:
     HAS_ANSIBLE = False
 
@@ -124,6 +128,10 @@ def get_template(custom_template, markdown):
 
 def render_docs(output, modules, custom_template, markdown):
     template, extension = get_template(custom_template, markdown)
+    try:
+        init_plugin_loader()
+    except NameError:
+        pass
     for module in modules:
         render_module_docs(output, module, template, extension)
 


### PR DESCRIPTION
Uses `init_plugin_loader` to initialize the collection loader before trying to use fragment loader to resolve doc_fragments.

This should fix #29 but with the caveat that this piece of api was introduced into ansible-core 2.15, so this will not work in versions of ansible-core lower than 2.15. However all those versions are now out of support https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html